### PR TITLE
add license information to project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,8 @@
 (defproject utilize "0.2.3"
   :description "Compilation of Clojure functions from around the community"
   :url "https://github.com/AlexBaranosky/Utilize"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dev-dependencies [[midje "1.3.0"]]
   :dependencies [[clojure "1.3.0"]
                  [org.clojure/tools.macro "0.1.1"]


### PR DESCRIPTION
Having license information in your project.clj makes it a little easier for users of your library to extract licensing and ensure compliance.
